### PR TITLE
✨ Make the BOMs parametrizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,41 @@
 
 Generate project
 
+if you want to use Camel for Spring Boot dependencies
 ```
 mvn archetype:generate \
 -DarchetypeGroupId=software.tnb \
 -DarchetypeArtifactId=camel3-archetype-spring-boot \
--DarchetypeVersion=0.1.4 \
+-DarchetypeVersion=0.1.8-SNAPSHOT \
 -DgroupId=test.group \
 -DartifactId=build-it \
 -Dversion=0.0.1 \
 -Dpackage=org.apache.camel.archetypes.archetypeIT \
--Dmaven-compiler-plugin-version=3.8.1 \
--Dspring-boot-version=2.7.8 \
--Dcamel-spring-boot-version=3.20.1.redhat-00023 \
+-Ddefault-spring-boot-version=2.7.8 \
+-Ddefault-camel-spring-boot-version=3.20.1 \
 -B
 ```
+
+if you want to use Red Hat platform dependencies add the parameter `-Ddependencies-resolution=redhat-platform` in this case the parameter `default-spring-boot-version` will be used only for `spring-boot-maven-plugin:repackage` maven goal, the Spring Boot version is resolved from the platform BOM 
+
+```
+mvn archetype:generate \
+-DarchetypeGroupId=software.tnb \
+-DarchetypeArtifactId=camel3-archetype-spring-boot \
+-DarchetypeVersion=0.1.8-SNAPSHOT \
+-DgroupId=test.group \
+-DartifactId=build-it \
+-Dversion=0.0.1 \
+-Dpackage=org.apache.camel.archetypes.archetypeIT \
+-Ddefault-spring-boot-version=2.7.8 \
+-Ddefault-camel-spring-boot-version=3.20.1.redhat-00023 \
+-Ddependencies-resolution=redhat-platform \
+-B
+```
+
+it is also possible to generate maven module with specific:
+
+- `maven-surefire-plugin-version`
+- `maven-compiler-plugin-version`
+- `java-version` (default 11)
+- `encoding` (default UTF-8)

--- a/pom.xml
+++ b/pom.xml
@@ -71,15 +71,22 @@
 	</distributionManagement>
 
 	<properties>
-		<maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
 		<maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-		<maven.javadoc.plugin.version>3.4.0</maven.javadoc.plugin.version>
+		<maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
 		<nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
 		<maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
-		<spring-boot-version>2.7.8</spring-boot-version>
-		<camel-spring-boot-version>3.20.1.redhat-00023</camel-spring-boot-version>
 		<archetype.test.settingsFile>src/test/resources/settings.xml</archetype.test.settingsFile> <!-- Needed to download camel-spring-boot snapshots -->
 		<archetype-packaging.version>3.2.1</archetype-packaging.version>
+		<maven-compiler-plugin-version>3.10.1</maven-compiler-plugin-version>
+		<maven-surefire-plugin-version>3.0.0-M8</maven-surefire-plugin-version>
+		<dependencies-resolution>csb-dependencies</dependencies-resolution>
+		<java-version>11</java-version>
+		<encoding>UTF-8</encoding>
+		<project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
+		<!-- properties overrideable at runtime -->
+		<default-camel-spring-boot-version>3.20.1.redhat-00023</default-camel-spring-boot-version>
+		<default-spring-boot-version>2.7.8</default-spring-boot-version>
 	</properties>
 
     <build>

--- a/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -21,14 +21,26 @@
     xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <requiredProperties>
-    <requiredProperty key="spring-boot-version">
-      <defaultValue>${spring-boot-version}</defaultValue>
+    <requiredProperty key="default-spring-boot-version">
+      <defaultValue>${default-spring-boot-version}</defaultValue>
     </requiredProperty>
-    <requiredProperty key="camel-spring-boot-version">
-      <defaultValue>${camel-spring-boot-version}</defaultValue>
+    <requiredProperty key="default-camel-spring-boot-version">
+      <defaultValue>${default-camel-spring-boot-version}</defaultValue>
     </requiredProperty>
     <requiredProperty key="maven-compiler-plugin-version">
       <defaultValue>${maven-compiler-plugin-version}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="maven-surefire-plugin-version">
+      <defaultValue>${maven-surefire-plugin-version}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="dependencies-resolution">
+      <defaultValue>${dependencies-resolution}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="java-version">
+      <defaultValue>${java-version}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="encoding">
+      <defaultValue>${encoding}</defaultValue>
     </requiredProperty>
   </requiredProperties>
   <fileSets>
@@ -60,6 +72,8 @@
       <directory/>
       <includes>
         <include>readme.adoc</include>
+        <include>csb-dependencies/**</include>
+        <include>redhat-platform/**</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,0 +1,24 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+// the path where the project got generated
+Path projectPath = Paths.get(request.outputDirectory, request.artifactId)
+
+// dependencyResolution is the name of the folder for pom.xml provisioning
+String dependencyResolution = request.properties.get("dependencies-resolution")
+
+//remove default pom.xml
+Files.deleteIfExists projectPath.resolve("pom.xml")
+
+//copy selected version
+Files.copy projectPath.resolve("${dependencyResolution}/pom.xml"),projectPath.resolve("pom.xml")
+Files.copy projectPath.resolve("${dependencyResolution}/readme.adoc"),projectPath.resolve("readme.adoc")
+
+//remove unnecessary files
+Files.deleteIfExists projectPath.resolve("csb-dependencies/pom.xml")
+Files.deleteIfExists projectPath.resolve("csb-dependencies/readme.adoc")
+Files.deleteIfExists projectPath.resolve("csb-dependencies")
+Files.deleteIfExists projectPath.resolve("redhat-platform/pom.xml")
+Files.deleteIfExists projectPath.resolve("redhat-platform/readme.adoc")
+Files.deleteIfExists projectPath.resolve("redhat-platform")

--- a/src/main/resources/archetype-resources/csb-dependencies/pom.xml
+++ b/src/main/resources/archetype-resources/csb-dependencies/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+## ------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ------------------------------------------------------------------------
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
+  <packaging>jar</packaging>
+  <version>${version}</version>
+
+  <name>A Camel Spring Boot Route</name>
+
+  <properties>
+    <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
+    <maven.compiler.source>${java-version}</maven.compiler.source>
+    <maven.compiler.target>${java-version}</maven.compiler.target>
+    <maven.compiler.release>${java-version}</maven.compiler.release>
+    <spring-boot-version>${default-spring-boot-version}</spring-boot-version>
+    <camel-spring-boot-version>${default-camel-spring-boot-version}</camel-spring-boot-version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Spring Boot BOM -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Camel BOM -->
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-spring-boot-bom</artifactId>
+        <version>${camel-spring-boot-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-spring-boot-starter</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin-version}</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin-version}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>openshift</id>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-web</artifactId>
+          <exclusions>
+            <exclusion>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-starter-tomcat</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-undertow</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+</project>

--- a/src/main/resources/archetype-resources/csb-dependencies/readme.adoc
+++ b/src/main/resources/archetype-resources/csb-dependencies/readme.adoc
@@ -1,0 +1,40 @@
+= Camel Example Spring Boot
+
+This example shows how to work with a simple Apache Camel application using Spring Boot.
+
+The example generates messages using timer trigger, writes them to standard output.
+
+== Camel routes
+
+The Camel route is located in the `MyCamelRouter` class. In this class the route
+starts from a timer, that triggers every 2nd second and calls a Spring Bean `MyBean`
+which returns a message, that is routed to a stream endpoint which writes to standard output.
+The example contains test class demonstrating how to intercept and mock endpoints in unit tests using JUnit 5 and Camel Test Support.
+
+== Using Camel components
+
+Apache Camel provides 300+ components which you can use to integrate and route messages between many systems
+and data formats. To use any of these Camel components, add the component as a dependency to your project.
+
+== How to run
+
+You can run this example using
+
+    mvn spring-boot:run
+
+== How to run test
+
+You can run unit test of this example using
+
+    mvn clean test
+
+== More information
+
+You can find more information about Apache Camel at the website: http://camel.apache.org/
+
+== You can specify the version of Camel Spring Boot and Spring Boot to use
+
+    mvn -Dcamel-spring-boot-version=3.20.1 -Dspring-boot-version=2.7.8 spring-boot:run
+
+
+

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -16,99 +16,11 @@
 ## limitations under the License.
 ## ------------------------------------------------------------------------
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <modelVersion>4.0.0</modelVersion>
-
-  <groupId>${groupId}</groupId>
-  <artifactId>${artifactId}</artifactId>
-  <packaging>jar</packaging>
-  <version>${version}</version>
-
-  <name>A Camel Spring Boot Route</name>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.boot-version>${spring-boot-version}</spring.boot-version>
-    <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.redhat.camel.springboot.platform</groupId>
-        <artifactId>camel-springboot-bom</artifactId>
-        <version>${camel-spring-boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.camel.springboot</groupId>
-      <artifactId>camel-spring-boot-starter</artifactId>
-    </dependency>
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin-version}</version>
-        <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring.boot-version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.plugin.version}</version>
-      </plugin>
-    </plugins>
-  </build>
-
-  <profiles>
-    <profile>
-      <id>openshift</id>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-web</artifactId>
-          <exclusions>
-            <exclusion>
-              <groupId>org.springframework.boot</groupId>
-              <artifactId>spring-boot-starter-tomcat</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-undertow</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
+	<groupId>${groupId}</groupId>
+	<artifactId>${artifactId}</artifactId>
+	<packaging>jar</packaging>
+	<version>${version}</version>
 </project>

--- a/src/main/resources/archetype-resources/redhat-platform/pom.xml
+++ b/src/main/resources/archetype-resources/redhat-platform/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+## ------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ------------------------------------------------------------------------
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
+  <packaging>jar</packaging>
+  <version>${version}</version>
+
+  <name>A Camel Spring Boot Route</name>
+
+  <properties>
+    <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
+    <maven.compiler.source>${java-version}</maven.compiler.source>
+    <maven.compiler.target>${java-version}</maven.compiler.target>
+    <maven.compiler.release>${java-version}</maven.compiler.release>
+    <spring-boot-version>${default-spring-boot-version}</spring-boot-version>
+    <camel-spring-boot-version>${default-camel-spring-boot-version}</camel-spring-boot-version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.redhat.camel.springboot.platform</groupId>
+        <artifactId>camel-springboot-bom</artifactId>
+        <version>${camel-spring-boot-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-spring-boot-starter</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin-version}</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin-version}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>openshift</id>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-web</artifactId>
+          <exclusions>
+            <exclusion>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-starter-tomcat</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-undertow</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+</project>

--- a/src/main/resources/archetype-resources/redhat-platform/readme.adoc
+++ b/src/main/resources/archetype-resources/redhat-platform/readme.adoc
@@ -32,5 +32,11 @@ You can run unit test of this example using
 
 You can find more information about Apache Camel at the website: http://camel.apache.org/
 
+== You can specify the version of Camel Spring Boot to use
+
+it is also possible to specify `spring-boot-version` used only for `spring-boot-maven-plugin:repackage` maven goal
+
+    mvn -Dcamel-spring-boot-version=3.20.1.redhat-00023 -Dspring-boot-version=2.7.8 spring-boot:run
+
 
 


### PR DESCRIPTION
It is possible to use different Maven BOM based on parameter `dependencies-resolution`.

By default the value is `csb-dependencies` and then the generated module will use both `spring-boot-dependencies` and `camel-spring-boot-bom`.

Otherwise if the specified value is `redhat-platform`, then only the platform BOM will be used.

In both cases the parameters `default-spring-boot-version` and `default-camel-spring-boot-version` will be used but for the platform BOM the parameter `default-spring-boot-version`  is used only for `spring-boot-maven-plugin:repackage` maven goal, the Spring Boot version is resolved from the platform BOM itself

Moreover it is possible to specify the Java compiler version with the parameter `java-version`

Other information on readme files